### PR TITLE
Add redirects for "esr" channels - point to same as "release" for now.

### DIFF
--- a/htaccess/thunderbird/releasenotes/.htaccess
+++ b/htaccess/thunderbird/releasenotes/.htaccess
@@ -1,7 +1,7 @@
     RewriteEngine On
 
     # Thunderbird Release 60+
-    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=(release|default)($|&)
+    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=(esr|release|default)($|&)
       RewriteRule .* https://www.thunderbird.net/en-US/thunderbird/%3/releasenotes/?uri=%{REQUEST_URI} [QSA,R=302,L]
 
     # Thunderbird Beta

--- a/htaccess/thunderbird/start/.htaccess
+++ b/htaccess/thunderbird/start/.htaccess
@@ -1,7 +1,7 @@
     RewriteEngine On
 
     # Thunderbird Release 60+
-    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=(release|release-localtest|release-cdntest|default)($|&)
+    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=(esr|esr-localtest|esr-cdntest|release|release-localtest|release-cdntest|default)($|&)
       RewriteRule .* https://start.thunderbird.net/%2/release/?uri=%{REQUEST_URI} [QSA,R=302,L]
 
     # Thunderbird Beta 60+

--- a/htaccess/thunderbird/whatsnew/.htaccess
+++ b/htaccess/thunderbird/whatsnew/.htaccess
@@ -1,7 +1,7 @@
     RewriteEngine On
 
     # Thunderbird Release 60+
-    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([0-9][0-9][0-9]?)([^?&]+)&channel=(release|default)($|&)
+    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([0-9][0-9][0-9]?)([^?&]+)&channel=(esr|release|default)($|&)
       RewriteRule .* https://www.thunderbird.net/%2/thunderbird/%3.0/whatsnew/ [QSA,R=302,L]
 
     # Thunderbird Beta


### PR DESCRIPTION
For migrating release channel users to esr.