### PR TITLE
Split off redirects for "esr" channel, still mostly points to release except for whatsnew.

### DIFF
--- a/htaccess/thunderbird/releasenotes/.htaccess
+++ b/htaccess/thunderbird/releasenotes/.htaccess
@@ -1,7 +1,11 @@
     RewriteEngine On
 
     # Thunderbird Release 60+
-    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=(esr|release|default)($|&)
+    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=(release|default)($|&)
+      RewriteRule .* https://www.thunderbird.net/en-US/thunderbird/%3/releasenotes/?uri=%{REQUEST_URI} [QSA,R=302,L]
+
+    # Thunderbird Extended Support Release 128.0+
+    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=esr($|&)
       RewriteRule .* https://www.thunderbird.net/en-US/thunderbird/%3/releasenotes/?uri=%{REQUEST_URI} [QSA,R=302,L]
 
     # Thunderbird Beta

--- a/htaccess/thunderbird/releasenotes/.htaccess
+++ b/htaccess/thunderbird/releasenotes/.htaccess
@@ -6,7 +6,7 @@
 
     # Thunderbird Extended Support Release 128.0+
     RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=esr($|&)
-      RewriteRule .* https://www.thunderbird.net/en-US/thunderbird/%3/releasenotes/?uri=%{REQUEST_URI} [QSA,R=302,L]
+      RewriteRule .* https://www.thunderbird.net/en-US/thunderbird/%3esr/releasenotes/?uri=%{REQUEST_URI} [QSA,R=302,L]
 
     # Thunderbird Beta
     RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=beta($|&)

--- a/htaccess/thunderbird/start/.htaccess
+++ b/htaccess/thunderbird/start/.htaccess
@@ -1,7 +1,11 @@
     RewriteEngine On
 
     # Thunderbird Release 60+
-    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=(esr|esr-localtest|esr-cdntest|release|release-localtest|release-cdntest|default)($|&)
+    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=(release|release-localtest|release-cdntest|default)($|&)
+      RewriteRule .* https://start.thunderbird.net/%2/release/?uri=%{REQUEST_URI} [QSA,R=302,L]
+
+    # Thunderbird Extended Support Release 128.0+
+    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=(esr|esr-localtest|esr-cdntest)($|&)
       RewriteRule .* https://start.thunderbird.net/%2/release/?uri=%{REQUEST_URI} [QSA,R=302,L]
 
     # Thunderbird Beta 60+

--- a/htaccess/thunderbird/whatsnew/.htaccess
+++ b/htaccess/thunderbird/whatsnew/.htaccess
@@ -1,8 +1,12 @@
     RewriteEngine On
 
     # Thunderbird Release 60+
-    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([0-9][0-9][0-9]?)([^?&]+)&channel=(esr|release|default)($|&)
+    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([0-9][0-9][0-9]?)([^?&]+)&channel=(release|default)($|&)
       RewriteRule .* https://www.thunderbird.net/%2/thunderbird/%3.0/whatsnew/ [QSA,R=302,L]
+
+    # Thunderbird Extended Support Release 128.0+
+    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([0-9][0-9][0-9]?)([^?&]+)&channel=esr($|&)
+      RewriteRule .* https://www.thunderbird.net/%2/thunderbird/%3.0esr/whatsnew/ [QSA,R=302,L]
 
     # Thunderbird Beta
     RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=beta($|&)

--- a/htaccess/thunderbird/whatsnew/.htaccess
+++ b/htaccess/thunderbird/whatsnew/.htaccess
@@ -5,7 +5,7 @@
       RewriteRule .* https://www.thunderbird.net/%2/thunderbird/%3.0/whatsnew/ [QSA,R=302,L]
 
     # Thunderbird Extended Support Release 128.0+
-    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([0-9][0-9][0-9]?)([^?&]+)&channel=esr($|&)
+    RewriteCond %{QUERY_STRING} (^|&)locale=([^?&]+)&version=([^?&]+)&channel=esr($|&)
       RewriteRule .* https://www.thunderbird.net/%2/thunderbird/%3.0esr/whatsnew/ [QSA,R=302,L]
 
     # Thunderbird Beta


### PR DESCRIPTION
Technically I think we only need to modify whatsnew, but just to be safe I've split off releasenotes and start. They don't do anything special but if we need to change them it's a little easier down the road. 

I've tested this with https://htaccess.madewithlove.com/ but htaccess rules are gross so feel free to test them out yourself!